### PR TITLE
Animation duration is now transitioning protocol variable

### DIFF
--- a/SwipeableTabBarController/Classes/SwipeTransitionAnimator.swift
+++ b/SwipeableTabBarController/Classes/SwipeTransitionAnimator.swift
@@ -14,10 +14,8 @@ import UIKit
 @objc(SwipeTransitionAnimator)
 class SwipeTransitionAnimator: NSObject, SwipeTransitioningProtocol {
 
-    /// Duration of the transition animation.
-    private var animationDuration: TimeInterval
-
     // MARK: - SwipeTransitioningProtocol
+    var animationDuration: TimeInterval
     var targetEdge: UIRectEdge
     var animationType: SwipeAnimationTypeProtocol = SwipeAnimationType.sideBySide
 

--- a/SwipeableTabBarController/Classes/SwipeTransitioningProtocol.swift
+++ b/SwipeableTabBarController/Classes/SwipeTransitioningProtocol.swift
@@ -13,6 +13,9 @@ import UIKit
 /// Added to support custom `UIViewControllerAnimatedTransitioning` in different applications.
 public protocol SwipeTransitioningProtocol: UIViewControllerAnimatedTransitioning {
 
+    /// Duration of the transition animation.
+    var animationDuration: TimeInterval { get set }
+
     /// Direction in which the animation will occur.
     var targetEdge: UIRectEdge { get set }
 


### PR DESCRIPTION
### Description

I think the duration of animation should be accessible for changes. Even if it is recommended to use default value (of ~330ms) some cases require to change this interval.