### PR TITLE
Animation completion

### DIFF
--- a/SwipeableTabBarController/Classes/SwipeAnimationType.swift
+++ b/SwipeableTabBarController/Classes/SwipeAnimationType.swift
@@ -16,6 +16,7 @@ public protocol SwipeAnimationTypeProtocol {
     func addTo(containerView: UIView, fromView: UIView, toView: UIView)
     func prepare(fromView from: UIView, toView to: UIView, direction: Direction)
     func animation(fromView from: UIView, toView to: UIView, direction: Direction)
+    func completion(fromView from: UIView, toView to: UIView, direction: Direction)
 }
 
 /// Different types of interactive animations.
@@ -81,6 +82,19 @@ public enum SwipeAnimationType: SwipeAnimationTypeProtocol {
         case .push:
             to.frame.origin.x = 0
             from.frame.origin.x = direction == .forward ? screenWidth : -screenWidth
+        }
+    }
+    
+    /// The completion to call upon finishing animation.
+    ///
+    /// - Parameters:
+    ///   - from: Previously selected tab view.
+    ///   - to: New selected tab view.
+    ///   - direction: Direction in which the views animated.
+    public func completion(fromView from: UIView, toView to: UIView, direction: Direction) {
+        switch self {
+        default:
+            return
         }
     }
 }

--- a/SwipeableTabBarController/Classes/SwipeAnimationType.swift
+++ b/SwipeableTabBarController/Classes/SwipeAnimationType.swift
@@ -10,10 +10,12 @@ import UIKit
 
 /// TODO (marcosgriselli): - Come up with a simpler protocol based on starting and ending vectors.
 
+public typealias Direction = UIPageViewController.NavigationDirection
+
 public protocol SwipeAnimationTypeProtocol {
     func addTo(containerView: UIView, fromView: UIView, toView: UIView)
-    func prepare(fromView from: UIView, toView to: UIView, direction: Bool)
-    func animation(fromView from: UIView, toView to: UIView, direction: Bool)
+    func prepare(fromView from: UIView, toView to: UIView, direction: Direction)
+    func animation(fromView from: UIView, toView to: UIView, direction: Direction)
 }
 
 /// Different types of interactive animations.
@@ -47,17 +49,17 @@ public enum SwipeAnimationType: SwipeAnimationTypeProtocol {
     ///   - from: Previously selected tab view.
     ///   - to: New selected tab view.
     ///   - direction: Direction in which the views will animate.
-    public func prepare(fromView from: UIView, toView to: UIView, direction: Bool) {
+    public func prepare(fromView from: UIView, toView to: UIView, direction: Direction) {
         let screenWidth = UIScreen.main.bounds.size.width
         switch self {
         case .overlap:
-            to.frame.origin.x = direction ? -screenWidth : screenWidth
+            to.frame.origin.x = direction == .forward ? -screenWidth : screenWidth
         case .sideBySide:
             from.frame.origin.x = 0
-            to.frame.origin.x = direction ? -screenWidth : screenWidth
+            to.frame.origin.x = direction == .forward ? -screenWidth : screenWidth
         case .push:
             let scaledWidth = screenWidth / 6
-            to.frame.origin.x = direction ? -scaledWidth : scaledWidth
+            to.frame.origin.x = direction == .forward ? -scaledWidth : scaledWidth
             from.frame.origin.x = 0
         }
     }
@@ -68,17 +70,17 @@ public enum SwipeAnimationType: SwipeAnimationTypeProtocol {
     ///   - from: Previously selected tab view.
     ///   - to: New selected tab view.
     ///   - direction: Direction in which the views will animate.
-    public func animation(fromView from: UIView, toView to: UIView, direction: Bool) {
+    public func animation(fromView from: UIView, toView to: UIView, direction: Direction) {
         let screenWidth = UIScreen.main.bounds.size.width
         switch self {
         case .overlap:
             to.frame.origin.x = 0
         case .sideBySide:
-            from.frame.origin.x = direction ? screenWidth : -screenWidth
+            from.frame.origin.x = direction == .forward ? screenWidth : -screenWidth
             to.frame.origin.x = 0
         case .push:
             to.frame.origin.x = 0
-            from.frame.origin.x = direction ? screenWidth : -screenWidth
+            from.frame.origin.x = direction == .forward ? screenWidth : -screenWidth
         }
     }
 }

--- a/SwipeableTabBarController/Classes/SwipeTransitionAnimator.swift
+++ b/SwipeableTabBarController/Classes/SwipeTransitionAnimator.swift
@@ -60,6 +60,7 @@ class SwipeTransitionAnimator: NSObject, SwipeTransitioningProtocol {
                        animations: {
                         self.animationType.animation(fromView: fromView, toView: toView, direction: direction)
         }, completion: { _ in
+            self.animationType.completion(fromView: fromView, toView: toView, direction: direction)
             transitionContext.completeTransition(!transitionContext.transitionWasCancelled)
         })
     }

--- a/SwipeableTabBarController/Classes/SwipeTransitionAnimator.swift
+++ b/SwipeableTabBarController/Classes/SwipeTransitionAnimator.swift
@@ -47,10 +47,10 @@ class SwipeTransitionAnimator: NSObject, SwipeTransitioningProtocol {
         let fromView = transitionContext.view(forKey: UITransitionContextViewKey.from)!
         let toView = transitionContext.view(forKey: UITransitionContextViewKey.to)!
         //swiftlint:enable force_unwrapping
-        let fromRight = targetEdge == .right
+        let direction: Direction = targetEdge == .right ? .forward : .reverse
 
         animationType.addTo(containerView: containerView, fromView: fromView, toView: toView)
-        animationType.prepare(fromView: fromView, toView: toView, direction: fromRight)
+        animationType.prepare(fromView: fromView, toView: toView, direction: direction)
         
         let duration = transitionDuration(using: transitionContext)
         
@@ -58,7 +58,7 @@ class SwipeTransitionAnimator: NSObject, SwipeTransitioningProtocol {
                        delay: 0,
                        options: [.curveLinear],
                        animations: {
-                        self.animationType.animation(fromView: fromView, toView: toView, direction: fromRight)
+                        self.animationType.animation(fromView: fromView, toView: toView, direction: direction)
         }, completion: { _ in
             transitionContext.completeTransition(!transitionContext.transitionWasCancelled)
         })


### PR DESCRIPTION
### Description

* `SwipeAnimationTypeProtocol` now uses `UIPageViewController.NavigationDirection` (with typealias) to describe direction instead of `Bool`.
* Adds completion function to `SwipeAnimationTypeProtocol`, which is called after finishing animation. This may not be needed by currently used animation types, but I will add a new type in a moment, which will use it.